### PR TITLE
Keep Sidebar fixed + refactor Sidebar.tsx

### DIFF
--- a/compass/app/admin/layout.tsx
+++ b/compass/app/admin/layout.tsx
@@ -2,7 +2,6 @@
 
 import Sidebar from "@/components/Sidebar/Sidebar";
 import React, { useState } from "react";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
 import { createClient } from "@/utils/supabase/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -56,34 +55,13 @@ export default function RootLayout({
         <div className="flex-row">
             {user ? (
                 <div>
-                    {/* button to open sidebar */}
-                    <button
-                        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                        className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
-                        aria-label={"Open sidebar"}
-                    >
-                        {
-                            !isSidebarOpen && (
-                                <ChevronDoubleRightIcon className="h-5 w-5" />
-                            ) // Icon for closing the sidebar
-                        }
-                    </button>
-                    {/* sidebar  */}
-                    <div
-                        className={`absolute inset-y-0 left-0 transform ${
-                            isSidebarOpen
-                                ? "translate-x-0"
-                                : "-translate-x-full"
-                        } w-64 transition duration-300 ease-in-out`}
-                    >
-                        <Sidebar
-                            setIsSidebarOpen={setIsSidebarOpen}
-                            name={user.username}
-                            email={user.email}
-                            isAdmin={user.role === Role.ADMIN}
-                        />
-                    </div>
-                    {/* page ui  */}
+                    <Sidebar
+                        setIsSidebarOpen={setIsSidebarOpen}
+                        isSidebarOpen={isSidebarOpen}
+                        name={user.username}
+                        email={user.email}
+                        isAdmin={user.role === Role.ADMIN}
+                    />
                     <div
                         className={`flex-1 transition duration-300 ease-in-out ${
                             isSidebarOpen ? "ml-64" : "ml-0"

--- a/compass/app/admin/layout.tsx
+++ b/compass/app/admin/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const router = useRouter();
     const [user, setUser] = useState<User>();
 

--- a/compass/app/home/layout.tsx
+++ b/compass/app/home/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const [user, setUser] = useState<User>();
     const router = useRouter();
 

--- a/compass/app/home/layout.tsx
+++ b/compass/app/home/layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Sidebar from "@/components/Sidebar/Sidebar";
 import React, { useState } from "react";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
 import { createClient } from "@/utils/supabase/client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -45,34 +44,13 @@ export default function RootLayout({
         <div className="flex-row">
             {user ? (
                 <div>
-                    {/* button to open sidebar */}
-                    <button
-                        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                        className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
-                        aria-label={"Open sidebar"}
-                    >
-                        {
-                            !isSidebarOpen && (
-                                <ChevronDoubleRightIcon className="h-5 w-5" />
-                            ) // Icon for closing the sidebar
-                        }
-                    </button>
-                    {/* sidebar  */}
-                    <div
-                        className={`absolute inset-y-0 left-0 transform ${
-                            isSidebarOpen
-                                ? "translate-x-0"
-                                : "-translate-x-full"
-                        } w-64 transition duration-300 ease-in-out`}
-                    >
-                        <Sidebar
-                            name={user.username}
-                            email={user.email}
-                            setIsSidebarOpen={setIsSidebarOpen}
-                            isAdmin={user.role === Role.ADMIN}
-                        />
-                    </div>
-                    {/* page ui  */}
+                    <Sidebar
+                        name={user.username}
+                        email={user.email}
+                        setIsSidebarOpen={setIsSidebarOpen}
+                        isSidebarOpen={isSidebarOpen}
+                        isAdmin={user.role === Role.ADMIN}
+                    />
                     <div
                         className={`flex-1 transition duration-300 ease-in-out ${
                             isSidebarOpen ? "ml-64" : "ml-0"

--- a/compass/app/resource/layout.tsx
+++ b/compass/app/resource/layout.tsx
@@ -61,20 +61,21 @@ export default function RootLayout({
                         }
                     </button>
                     {/* sidebar  */}
-                    <div
+                    {/* <div
                         className={`absolute inset-y-0 left-0 transform ${
                             isSidebarOpen
                                 ? "translate-x-0"
                                 : "-translate-x-full"
                         } w-64 transition duration-300 ease-in-out`}
-                    >
+                    > */}
                         <Sidebar
                             setIsSidebarOpen={setIsSidebarOpen}
+                            isSidebarOpen={isSidebarOpen}
                             name={user.username}
                             email={user.email}
                             isAdmin={user.role === Role.ADMIN}
                         />
-                    </div>
+                    { /* </div>*/ }
                     {/* page ui  */}
                     <div
                         className={`flex-1 transition duration-300 ease-in-out ${

--- a/compass/app/resource/layout.tsx
+++ b/compass/app/resource/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const router = useRouter();
     const [user, setUser] = useState<User>();
 

--- a/compass/app/resource/layout.tsx
+++ b/compass/app/resource/layout.tsx
@@ -2,7 +2,6 @@
 
 import Sidebar from "@/components/Sidebar/Sidebar";
 import React, { useState } from "react";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
 import { createClient } from "@/utils/supabase/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -48,34 +47,14 @@ export default function RootLayout({
         <div className="flex-row">
             {user ? (
                 <div>
-                    {/* button to open sidebar */}
-                    <button
-                        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                        className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
-                        aria-label={"Open sidebar"}
-                    >
-                        {
-                            !isSidebarOpen && (
-                                <ChevronDoubleRightIcon className="h-5 w-5" />
-                            ) // Icon for closing the sidebar
-                        }
-                    </button>
-                    {/* sidebar  */}
-                    {/* <div
-                        className={`absolute inset-y-0 left-0 transform ${
-                            isSidebarOpen
-                                ? "translate-x-0"
-                                : "-translate-x-full"
-                        } w-64 transition duration-300 ease-in-out`}
-                    > */}
-                        <Sidebar
-                            setIsSidebarOpen={setIsSidebarOpen}
-                            isSidebarOpen={isSidebarOpen}
-                            name={user.username}
-                            email={user.email}
-                            isAdmin={user.role === Role.ADMIN}
-                        />
-                    { /* </div>*/ }
+                    <Sidebar
+                        setIsSidebarOpen={setIsSidebarOpen}
+                        isSidebarOpen={isSidebarOpen}
+                        name={user.username}
+                        email={user.email}
+                        isAdmin={user.role === Role.ADMIN}
+                    />
+                    {/* </div>*/}
                     {/* page ui  */}
                     <div
                         className={`flex-1 transition duration-300 ease-in-out ${

--- a/compass/app/service/layout.tsx
+++ b/compass/app/service/layout.tsx
@@ -2,7 +2,6 @@
 
 import Sidebar from "@/components/Sidebar/Sidebar";
 import React, { useState } from "react";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
 import { createClient } from "@/utils/supabase/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -48,34 +47,13 @@ export default function RootLayout({
         <div className="flex-row">
             {user ? (
                 <div>
-                    {/* button to open sidebar */}
-                    <button
-                        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                        className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
-                        aria-label={"Open sidebar"}
-                    >
-                        {
-                            !isSidebarOpen && (
-                                <ChevronDoubleRightIcon className="h-5 w-5" />
-                            ) // Icon for closing the sidebar
-                        }
-                    </button>
-                    {/* sidebar  */}
-                    <div
-                        className={`absolute inset-y-0 left-0 transform ${
-                            isSidebarOpen
-                                ? "translate-x-0"
-                                : "-translate-x-full"
-                        } w-64 transition duration-300 ease-in-out`}
-                    >
-                        <Sidebar
-                            setIsSidebarOpen={setIsSidebarOpen}
-                            name={user.username}
-                            email={user.email}
-                            isAdmin={user.role === Role.ADMIN}
-                        />
-                    </div>
-                    {/* page ui  */}
+                    <Sidebar
+                        setIsSidebarOpen={setIsSidebarOpen}
+                        isSidebarOpen={isSidebarOpen}
+                        name={user.username}
+                        email={user.email}
+                        isAdmin={user.role === Role.ADMIN}
+                    />
                     <div
                         className={`flex-1 transition duration-300 ease-in-out ${
                             isSidebarOpen ? "ml-64" : "ml-0"

--- a/compass/app/service/layout.tsx
+++ b/compass/app/service/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const router = useRouter();
     const [user, setUser] = useState<User>();
 

--- a/compass/components/Sidebar/Sidebar.tsx
+++ b/compass/components/Sidebar/Sidebar.tsx
@@ -31,21 +31,24 @@ const Sidebar: React.FC<SidebarProps> = ({
             {/* Button to open the sidebar. */}
             <button
                 onClick={() => setIsSidebarOpen(true)}
-                className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
+                className={
+                    "fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0"
+                }
                 aria-label={"Open sidebar"}
             >
                 {!isSidebarOpen && (
                     <ChevronDoubleRightIcon className="h-5 w-5" />
                 )}
             </button>
+
             {/* The sidebar itself. */}
             <div
                 className={
                     "fixed left-0 w-64 h-full border border-gray-200 bg-gray-50 px-4 " +
                     (isSidebarOpen
-                        ? "translate-x-0"
-                        : "-translate-x-full opacity-25") +
-                    " transition duration-300 ease-in-out"
+                        ? "translate-x-0" // Open
+                        : "-translate-x-full opacity-25") + // Closed
+                    " transition duration-300 ease-out" // More animation properties
                 }
             >
                 {/* Button to close sidebar  */}
@@ -58,6 +61,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                         <ChevronDoubleLeftIcon className="h-5 w-5" />
                     </button>
                 </div>
+
                 <div className="flex flex-col space-y-8">
                     {/* user + logout button  */}
                     <div className="flex items-center p-4 space-x-2 border border-gray-200 rounded-md ">

--- a/compass/components/Sidebar/Sidebar.tsx
+++ b/compass/components/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
     HomeIcon,
     ChevronDoubleLeftIcon,
+    ChevronDoubleRightIcon,
     BookmarkIcon,
     ClipboardIcon,
     BookOpenIcon,
@@ -26,67 +27,86 @@ const Sidebar: React.FC<SidebarProps> = ({
     isAdmin: admin,
 }) => {
     return (
-        <div className={"fixed left-0 w-64 h-full border border-gray-200 bg-gray-50 px-4 "
-            + (isSidebarOpen ? "translate-x-0" : "-translate-x-full opacity-25")
-            + " transition duration-300 ease-out"}>
-        {/* button to close sidebar  */}
-            <div className="flex justify-end">
-                <button
-                    onClick={() => setIsSidebarOpen(false)}
-                    className="py-2 text-gray-500 hover:text-gray-800"
-                    aria-label="Close sidebar"
-                >
-                    <ChevronDoubleLeftIcon className="h-5 w-5" />
-                </button>
-            </div>
-            <div className="flex flex-col space-y-8">
-                {/* user + logout button  */}
-                <div className="flex items-center p-4 space-x-2 border border-gray-200 rounded-md ">
-                    <UserProfile name={name} email={email} />
+        <>
+            {/* Button to open the sidebar. */}
+            <button
+                onClick={() => setIsSidebarOpen(true)}
+                className={`fixed z-20 p-2 text-gray-500 hover:text-gray-800 left-0`}
+                aria-label={"Open sidebar"}
+            >
+                {!isSidebarOpen && (
+                    <ChevronDoubleRightIcon className="h-5 w-5" />
+                )}
+            </button>
+            {/* The sidebar itself. */}
+            <div
+                className={
+                    "fixed left-0 w-64 h-full border border-gray-200 bg-gray-50 px-4 " +
+                    (isSidebarOpen
+                        ? "translate-x-0"
+                        : "-translate-x-full opacity-25") +
+                    " transition duration-300 ease-in-out"
+                }
+            >
+                {/* Button to close sidebar  */}
+                <div className="flex justify-end">
+                    <button
+                        onClick={() => setIsSidebarOpen(false)}
+                        className="py-2 text-gray-500 hover:text-gray-800"
+                        aria-label="Close sidebar"
+                    >
+                        <ChevronDoubleLeftIcon className="h-5 w-5" />
+                    </button>
                 </div>
-                {/* navigation menu  */}
-                <div className="flex flex-col space-y-2">
-                    <h4 className="text-xs font-semibold text-gray-500">
-                        Pages
-                    </h4>
-                    <nav className="flex flex-col">
-                        {admin && (
-                            <SidebarItem
-                                icon={<LockClosedIcon />}
-                                text="Admin"
-                                active={true}
-                                redirect="/admin"
-                            />
-                        )}
+                <div className="flex flex-col space-y-8">
+                    {/* user + logout button  */}
+                    <div className="flex items-center p-4 space-x-2 border border-gray-200 rounded-md ">
+                        <UserProfile name={name} email={email} />
+                    </div>
+                    {/* navigation menu  */}
+                    <div className="flex flex-col space-y-2">
+                        <h4 className="text-xs font-semibold text-gray-500">
+                            Pages
+                        </h4>
+                        <nav className="flex flex-col">
+                            {admin && (
+                                <SidebarItem
+                                    icon={<LockClosedIcon />}
+                                    text="Admin"
+                                    active={true}
+                                    redirect="/admin"
+                                />
+                            )}
 
-                        <SidebarItem
-                            icon={<HomeIcon />}
-                            text="Home"
-                            active={true}
-                            redirect="/home"
-                        />
-                        <SidebarItem
-                            icon={<BookmarkIcon />}
-                            text="Resources"
-                            active={true}
-                            redirect="/resource"
-                        />
-                        <SidebarItem
-                            icon={<ClipboardIcon />}
-                            text="Services"
-                            active={true}
-                            redirect="/service"
-                        />
-                        <SidebarItem
-                            icon={<BookOpenIcon />}
-                            text="Training Manuals"
-                            active={true}
-                            redirect="/training-manuals"
-                        />
-                    </nav>
+                            <SidebarItem
+                                icon={<HomeIcon />}
+                                text="Home"
+                                active={true}
+                                redirect="/home"
+                            />
+                            <SidebarItem
+                                icon={<BookmarkIcon />}
+                                text="Resources"
+                                active={true}
+                                redirect="/resource"
+                            />
+                            <SidebarItem
+                                icon={<ClipboardIcon />}
+                                text="Services"
+                                active={true}
+                                redirect="/service"
+                            />
+                            <SidebarItem
+                                icon={<BookOpenIcon />}
+                                text="Training Manuals"
+                                active={true}
+                                redirect="/training-manuals"
+                            />
+                        </nav>
+                    </div>
                 </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/compass/components/Sidebar/Sidebar.tsx
+++ b/compass/components/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { UserProfile } from "../resource/UserProfile";
 
 interface SidebarProps {
     setIsSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    isSidebarOpen: boolean;
     name: string;
     email: string;
     isAdmin: boolean;
@@ -19,13 +20,16 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({
     setIsSidebarOpen,
+    isSidebarOpen,
     name,
     email,
     isAdmin: admin,
 }) => {
     return (
-        <div className="w-64 h-full border border-gray-200 bg-gray-50 px-4">
-            {/* button to close sidebar  */}
+        <div className={"fixed left-0 w-64 h-full border border-gray-200 bg-gray-50 px-4 "
+            + (isSidebarOpen ? "translate-x-0" : "-translate-x-full opacity-25")
+            + " transition duration-300 ease-out"}>
+        {/* button to close sidebar  */}
             <div className="flex justify-end">
                 <button
                     onClick={() => setIsSidebarOpen(false)}


### PR DESCRIPTION
> [!NOTE]
> **Current Status**: Implemented. 
> ~~⚠️ Doesn't work on shorter devices, will look into later.~~ Seems fine at a brief glance?
> ~~Submitting as draft for review on the direction I'm taking.~~ Complete and ready for review.

At the moment, the sidebar does not stay fixed while scrolling the page. This PR aims to fix that--but also refactoring the Sidebar to keep state contained in the component itself without having to write extra code around it on each page it is included in.
Moved some code (specifically the outer div that adds transitions, and the open button) into the Sidebar component itself. This reduces boilerplate on each page that uses the sidebar, but does add a required `isSidebarOpen` prop that must be passed in.

~~Fingers crossed this PR doesn't grow in scope too much.~~ It probably didn't.


